### PR TITLE
Check dev dependencies before running tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ Jeweler::Tasks.new do |gem|
 
   gem.add_dependency 'tzinfo'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', "~> 2.0"
   gem.add_development_dependency 'jeweler'
 
   # gemspec spec : http://www.rubygems.org/read/chapter/20

--- a/rufus-scheduler.gemspec
+++ b/rufus-scheduler.gemspec
@@ -89,18 +89,18 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<tzinfo>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
-      s.add_development_dependency(%q<rspec>, [">= 0"])
+      s.add_development_dependency(%q<rspec>, ["~> 2.0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
       s.add_dependency(%q<tzinfo>, [">= 0"])
       s.add_dependency(%q<rake>, [">= 0"])
-      s.add_dependency(%q<rspec>, [">= 0"])
+      s.add_dependency(%q<rspec>, ["~> 2.0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
     s.add_dependency(%q<tzinfo>, [">= 0"])
     s.add_dependency(%q<rake>, [">= 0"])
-    s.add_dependency(%q<rspec>, [">= 0"])
+    s.add_dependency(%q<rspec>, ["~> 2.0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
   end
 end


### PR DESCRIPTION
When you try to run the tests without the right version of RSpec installed, you get an error like this:

```
$ rake
(in /Users/chrisk/rufus-scheduler)
rspec spec/
rake aborted!
Command failed with status (127): [rspec spec/...]
/Users/chrisk/rufus-scheduler/Rakefile:20
(See full trace by running task with --trace)
```

I improved the Rakefile to use Jeweler's built-in dependency checking, so it says this, instead:

```
$ rake
(in /Users/chrisk/rufus-scheduler)
Missing some dependencies. Install them with the following commands:
  gem install rspec --version "~> 2.0"
```
