### PR TITLE
Makes specs pass on ruby 1.9.3-p194

### DIFF
--- a/lib/rufus/sc/jobs.rb
+++ b/lib/rufus/sc/jobs.rb
@@ -255,7 +255,7 @@ module Scheduler
     def self.known_params(*args)
 
       define_method :known_params do
-        super + args
+        super() + args
       end
     end
 


### PR DESCRIPTION
and of course passing on 1.8.7 and 1.9.2 too
