### PR TITLE
Reject invalid weekday expressions

### DIFF
--- a/lib/rufus/sc/cronline.rb
+++ b/lib/rufus/sc/cronline.rb
@@ -192,10 +192,14 @@ module Rufus
           (monthdays ||= []) << it
 
         else
+          expr = it.dup
+          WEEKDAYS.each_with_index { |a, i| expr.gsub!(/#{a}/, i.to_s) }
 
-          WEEKDAYS.each_with_index { |a, i| it.gsub!(/#{a}/, i.to_s) }
+          raise ArgumentError.new(
+            "invalid weekday expression (#{it})"
+          ) if expr !~ /^0*[0-7](-0*[0-7])?$/
 
-          its = it.index('-') ? parse_range(it, 0, 7) : [ Integer(it) ]
+          its = expr.index('-') ? parse_range(expr, 0, 7) : [ Integer(expr) ]
           its = its.collect { |i| i == 7 ? 0 : i }
 
           (weekdays ||= []).concat(its)

--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -56,6 +56,13 @@ describe Rufus::CronLine do
       to_a '0 0 1 1 *', [ [0], [0], [0], [1], [1], nil, nil, nil ]
     end
 
+    it 'rejects invalid weekday expressions' do
+      lambda { cl '0 17 * * MON_FRI' }.should raise_error # underline instead of dash
+      lambda { cl '* * * * 9' }.should raise_error
+      lambda { cl '* * * * 0-12' }.should raise_error
+      lambda { cl '* * * * BLABLA' }.should raise_error
+    end
+
     it 'interprets cron strings with TZ correctly' do
 
       to_a '* * * * * EST', [ [0], nil, nil, nil, nil, nil, nil, 'EST' ]


### PR DESCRIPTION
We're using CronLine.new(expr) as a quick (maybe dirty) way to validate cron expressions entered by our users. For the expression "0 17 \* \* MON_FRI" the constructor returns a valid object, but calling next_time on it will block forever.

This pull requests prevents this bug by rejecting the invalid expression in the first place. Now weekday expressions must match a strict regex to be considered valid: `^0*[0-7](-0*[0-7])?$` (i.e., digits 0 to 7, with optional leading zeroes, and optional range). The matching is done after replacing weekday names with numbers.
