### PR TITLE
Support negative value within Rufus.parse_time_string()

### DIFF
--- a/lib/rufus/sc/rtime.rb
+++ b/lib/rufus/sc/rtime.rb
@@ -121,22 +121,10 @@ module Rufus
   #   Rufus.parse_time_string "1w2d"   # => 777600.0
   #
   def Rufus.parse_time_string(string)
-
-    if m = string.match(/^(-?\d*)\.?(\d*)([A-Za-z])(.*)$/)
-
-      number = "#{m[1]}.#{m[2]}".to_f
-      multiplier = DURATIONS[m[3]]
-
-      raise ArgumentError.new("unknown time char '#{m[3]}'") unless multiplier
-
-      return number * multiplier + parse_time_string(m[4])
-
+    if m = string.match(/^-(.*)$/)
+      return parse_time_string_recursive(m[1]) * -1.0
     else
-
-      return string.to_i / 1000.0 if string.match(/^-?\d+$/)
-      return string.to_f if string.match(/^-?\d*\.?\d*$/)
-
-      raise ArgumentError.new("cannot parse '#{string}'")
+      return parse_time_string_recursive(string)
     end
   end
 
@@ -330,6 +318,26 @@ module Rufus
   end
 
   protected
+
+  def Rufus.parse_time_string_recursive(string)
+
+    if m = string.match(/^(\d*)\.?(\d*)([A-Za-z])(.*)$/)
+    
+      number = "#{m[1]}.#{m[2]}".to_f
+      multiplier = DURATIONS[m[3]]
+
+      raise ArgumentError.new("unknown time char '#{m[3]}'") unless multiplier
+
+      return number * multiplier + parse_time_string_recursive(m[4])
+
+    else
+
+      return string.to_i / 1000.0 if string.match(/^\d+$/)
+      return string.to_f if string.match(/^\d*\.?\d*$/)
+
+      raise ArgumentError.new("cannot parse '#{string}'")
+    end
+  end
 
   DURATIONS2M = [
     [ 'y', 365 * 24 * 3600 ],

--- a/spec/rtime_spec.rb
+++ b/spec/rtime_spec.rb
@@ -24,13 +24,11 @@ describe 'rufus/rtime' do
 
   it 'parses duration strings' do
 
-    pts('-1.0d-1.0w-1.0d').should == -777600.0
-    pts('-1d-1w-1d').should == -777600.0
-    pts('-1w-2d').should == -777600.0
-    pts('-1.0d-1.0w1.0d').should == -604800.0
-    pts('-1d-1w1d').should == -604800.0
-    pts('-1h-10s').should == -3610.0
-    pts('-1h10s').should == -3590.0
+    pts('-1.0d1.0w1.0d').should == -777600.0
+    pts('-1d1w1d').should == -777600.0
+    pts('-1w2d').should == -777600.0
+    pts('-1h10s').should == -3610.0
+    pts('-1h').should == -3600.0
     pts('-5.').should == -5.0
     pts('-2.5s').should == -2.5
     pts('-1s').should == -1.0


### PR DESCRIPTION
This is a pretty useful function and this was the only thing missing to support negative values.

The specs are passing but unfortunately I've been unable to execute the /test/*. I get some errors with the event machine and a missing 'rufus/scheduler/em' file. I guessed they are out dated (4 years).
