### PR TITLE
Change hours range to 23 and refactor specs

### DIFF
--- a/lib/rufus/sc/cronline.rb
+++ b/lib/rufus/sc/cronline.rb
@@ -68,7 +68,7 @@ module Rufus
 
       @seconds = offset == 1 ? parse_item(items[0], 0, 59) : [ 0 ]
       @minutes = parse_item(items[0 + offset], 0, 59)
-      @hours = parse_item(items[1 + offset], 0, 24)
+      @hours = parse_item(items[1 + offset], 0, 23)
       @days = parse_item(items[2 + offset], 1, 31)
       @months = parse_item(items[3 + offset], 1, 12)
       @weekdays, @monthdays = parse_weekdays(items[4 + offset])

--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -84,7 +84,7 @@ describe Rufus::CronLine do
 
       to_a(
         '0 */2 * * *',
-        [ [0], [0], (0..12).collect { |e| e * 2 }, nil, nil, nil, nil, nil ])
+        [ [0], [0], (0..11).collect { |e| e * 2 }, nil, nil, nil, nil, nil ])
       to_a(
         '0 7-23/2 * * *',
         [ [0], [0], (7..23).select { |e| e.odd? }, nil, nil, nil, nil, nil ])
@@ -105,7 +105,7 @@ describe Rufus::CronLine do
       to_a '09 * * * *', [ [0], [9], nil, nil, nil, nil, nil, nil ]
       to_a '09-12 * * * *', [ [0], [9, 10, 11, 12], nil, nil, nil, nil, nil, nil ]
       to_a '07-08 * * * *', [ [0], [7, 8], nil, nil, nil, nil, nil, nil ]
-      to_a '* */08 * * *', [ [0], nil, [0, 8, 16, 24], nil, nil, nil, nil, nil ]
+      to_a '* */07 * * *', [ [0], nil, [0, 7, 14, 21], nil, nil, nil, nil, nil ]
       to_a '* 01-09/04 * * *', [ [0], nil, [1, 5, 9], nil, nil, nil, nil, nil ]
       to_a '* * * * 06', [ [0], nil, nil, nil, nil, [6], nil, nil ]
     end
@@ -153,6 +153,10 @@ describe Rufus::CronLine do
         # this one is slow (1 year == 3 seconds)
 
       nt('0 0 * * thu', now).should == now + 604800
+
+      nt('0 24 * * *', now).should == now + 82800
+        # Rufus::CronLine rounds integers >= 24 to 23
+        # Returns the 23rd hour
 
       now = local(2008, 12, 31, 23, 59, 59, 0)
 


### PR DESCRIPTION
This PR revises the hours range to 0..23 in the Rufus::CronLine class. 

Rufus::CronLine#next_time algorithm hangs when @hours = [24]. Example:

```
irb> require 'rufus-scheduler'
=> true
irb> c = Rufus::CronLine.new("0 24 * * *")
=> #<Rufus::CronLine:0x007fa47d16ed00 @original="0 24 * * *", @timezone=nil, @seconds=[0], @minutes=[0], @hours=[24], @days=nil, @months=nil, @weekdays=nil, @monthdays=nil>
irb(main):004:0> c.next_time # this will loop forever
```

This is not a problem if at least one valid value for @hours is provided (@hours = [0,24]). However it is misleading because cron jobs will run once less than the length of the @hours array. 

This issue is resolved by because all values greater than 23 are rounded down to 23 and #next_time runs as expected for that value.
