### PR TITLE
Return range max for istart when istart > max in #parse_range

### DIFF
--- a/lib/rufus/sc/cronline.rb
+++ b/lib/rufus/sc/cronline.rb
@@ -279,7 +279,10 @@ module Rufus
         iend = max
       end
 
-      istart = min if istart < min
+      istart = if istart < min then min
+               elsif istart > max then max
+               else istart
+               end
       iend = max if iend > max
 
       result = []

--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -52,6 +52,7 @@ describe Rufus::CronLine do
       to_a '1 * * * * *', [ [1], nil, nil, nil, nil, nil, nil, nil ]
       to_a '7 10-12 * * * *', [ [7], [10, 11, 12], nil, nil, nil, nil, nil, nil ]
       to_a '1-5 * * * * *', [ [1,2,3,4,5], nil, nil, nil, nil, nil, nil, nil ]
+      to_a '60-62 * 24-26 * * *', [ [59], nil, [23], nil, nil, nil, nil, nil ]
 
       to_a '0 0 1 1 *', [ [0], [0], [0], [1], [1], nil, nil, nil ]
     end


### PR DESCRIPTION
This PR resolves issue where Rufus::CronLine.new uses #parse_range and returns an invalid value for respective seconds, minutes and hours ranges.

Currently:

```
c = Rufus::CronLine.new("60-62 * * * *")
=> @minutes = [60]
c = Rufus::CronLine.new("* 25-26 * * *")
=> @hours = [25]
```

Both of these objects will loop forever when calling `c.next_time`.

This PR ensures the values returned for istart are no greater than the max value for their ranges.

So that

```
c = Rufus::CronLine.new("60-62 * * * *")
=> @minutes=[59]
irb(main):003:0> c = Rufus::CronLine.new("* 25-26 * * *")
=> @hours=[23]
```
