### PR TITLE
Fixed bad first impression with README.md docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,24 @@
 
 Job scheduler for Ruby (at, cron, in and every jobs).
 
+Quick QuickStart
 ```
 require 'rufus-scheduler'
 
-scheduler = Rufus::Scheduler.new
+scheduler = Rufus::Scheduler.start_new
+
+scheduler.in '3s' do
+  puts 'Hello... Rufus'
+end
+
+scheduler.join
+```
+
+A bit more enlightening QuickStart
+```
+require 'rufus-scheduler'
+
+scheduler = Rufus::Scheduler.start_new
 
 # ...
 


### PR DESCRIPTION
Changed the constructor from Rufus::Scheduler.new to Rufus::Scheduler.start_new.  This is probably a regression in the documentation.  Also, added a more brief quickstart section to show the scheduler actually working, instead of exiting immediately.
