### PR TITLE
Timeout issues when using mutexes

### DIFF
--- a/spec/timeout_spec.rb
+++ b/spec/timeout_spec.rb
@@ -121,5 +121,28 @@ describe "#{SCHEDULER_CLASS} timeouts" do
 
     @s.jobs.size.should == 0
   end
+
+  it 'times out properly after waiting for a mutex' do
+
+    mutex = Mutex.new
+    timedout = false
+
+    @s.in '0s', :mutex => mutex do
+      sleep 1
+    end
+
+    @s.in '0s', :mutex => mutex, :timeout => 0.1 do
+      begin
+        sleep 2
+      rescue Rufus::Scheduler::TimeOutError => e
+        timedout = true
+      end
+    end
+
+    sleep 2
+
+    @s.jobs.size.should == 0
+    timedout.should be_true
+  end
 end
 


### PR DESCRIPTION
Hi,

I don't know if you're still accepting pull requests to the 2.x branch; if you do:

We've been having some problems with timeouts not working reliably when mutexes are involved.

Basically, what happens is:
- Job is started
- Timeout job is scheduled
- Job blocks waiting for the mutex
- Timeout triggers, but does not see the waiting job, so does nothing
- Job finally acquires the mutex, but can no longer time out

This should fix it, by scheduling the timeout after the job has properly started and acquired its mutex.

Thanks
-Tobias
