### PR TITLE
make sure to cleanup everything if a job raises an exception

### DIFF
--- a/lib/rufus/sc/jobs.rb
+++ b/lib/rufus/sc/jobs.rb
@@ -203,6 +203,11 @@ module Scheduler
 
           trigger_block
 
+        rescue (@scheduler.options[:exception] || Exception) => e
+
+          @scheduler.do_handle_exception(self, e)
+
+        ensure
           job_thread[
             "rufus_scheduler__trigger_thread__#{@scheduler.object_id}"
           ] = nil
@@ -210,10 +215,6 @@ module Scheduler
           job_thread = nil
 
           to_job.unschedule if to_job
-
-        rescue (@scheduler.options[:exception] || Exception) => e
-
-          @scheduler.do_handle_exception(self, e)
         end
 
         @running = false


### PR DESCRIPTION
Hi,

Just in case you are maintaining this branch...

Previous code leads to throw timeout errors at random places if:
- the job fails
- the job thread is re-used for somthing else 

New master looks good but I've checked very quickly

By,
Thomas
