### PR TITLE
[DNM] Add failing specs for DST transitions

### DIFF
--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -371,6 +371,12 @@ describe Rufus::Scheduler::CronLine do
         )
       ).to eq(ltz('America/New_York', 2015, 3, 9, 2, 0, 0))
     end
+
+    it 'correctly increments through Daylight Savings Time' do
+      expect(
+        nt('* * * * * America/Los_Angeles', Time.utc(2015, 3, 8, 9, 59))
+      ).to eq(Time.utc(2015, 3, 8, 10, 00))
+    end
   end
 
   describe '#previous_time' do
@@ -433,6 +439,12 @@ describe Rufus::Scheduler::CronLine do
           ltz('America/New_York', 2015, 3, 9, 12, 0, 0)
         )
       ).to eq(ltz('America/New_York', 2015, 3, 9, 2, 0, 0))
+    end
+
+    it 'correctly decrements through Daylight Savings Time' do
+      expect(
+        pt('* * * * * America/Los_Angeles', Time.utc(2015, 3, 8, 10, 00))
+      ).to eq(Time.utc(2015, 3, 8, 9, 59))
     end
   end
 

--- a/spec/job_every_spec.rb
+++ b/spec/job_every_spec.rb
@@ -49,6 +49,17 @@ describe Rufus::Scheduler::EveryJob do
     expect(times[2] - times[1]).to be < 3.4
   end
 
+  context 'Daylight Savings Time' do
+    it 'triggers correctly through a DST transition' do
+      job = described_class.new(@scheduler, '1m', {}, lambda {})
+      t1 = ltz('America/Los_Angeles', 2015, 3, 8, 1, 55)
+      t2 = ltz('America/Los_Angeles', 2015, 3, 8, 3, 05)
+      job.next_time = t1
+      occurrences = job.occurrences(t1, t2)
+      expect(occurrences.length).to eq(11)
+    end
+  end
+
   context 'first_at/in' do
 
     it 'triggers for the first time at first_at' do


### PR DESCRIPTION
Working correctly on EveryJob, but not on CronJob.

We observed this bug over the weekend, where jobs scheduled with a cron line in a DST-affected time zone were not scheduled for an hour during the transition. I'm not sure exactly how to fix yet; there seem to be bugs in `Rufus::Scheduler::CronLine#next_time` and `Rufus::Scheduler::CronLine#previous_time`. As far as I can tell these methods are incrementing/decrementing the time in UTC; thus ignoring DST transitions. Apart from that there's a whole section of logic in `next_time` that's missing in `previous_time`, causing fairly different results as seen below.

My instinct would be to change this code to use `ActiveSupport::TimeWithZone` rather than reinventing the wheel, but I'm not sure how people feel about adding an extra dependency.

Output of the failing tests:

```
Failures:

  1) Rufus::Scheduler::CronLine#next_time correctly increments through Daylight Savings Time
     Failure/Error: expect(

       expected: 2015-03-08 10:00:00.000000000 +0000
            got: 2015-03-08 11:00:00.000000000 +0000

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -2015-03-08 10:00:00 UTC
       +2015-03-08 11:00:00 UTC

     # ./spec/cronline_spec.rb:376:in `block (3 levels) in <top (required)>'

  2) Rufus::Scheduler::CronLine#previous_time correctly decrements through Daylight Savings Time
     Failure/Error: expect(

       expected: 2015-03-08 09:59:00.000000000 +0000
            got: 2015-03-08 02:58:00.000000000 +0000

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -2015-03-08 09:59:00 UTC
       +2015-03-08 02:58:00 UTC

     # ./spec/cronline_spec.rb:445:in `block (3 levels) in <top (required)>'
```