### PR TITLE
zotime: attempt to require tzinfo

### DIFF
--- a/lib/rufus/scheduler/zotime.rb
+++ b/lib/rufus/scheduler/zotime.rb
@@ -24,6 +24,10 @@
 
 require 'rufus/scheduler/zones'
 
+begin
+  require 'tzinfo'
+rescue LoadError
+end
 
 class Rufus::Scheduler
 


### PR DESCRIPTION
When tzinfo is not explicitly required, I'm getting *dozens* of [failures][] running specs or consuming this library (e.g., via resque-scheduler) on my local dev environment, despite the [CI build][] looking ok:

OS: Mac OSX 10.8.5 (`x86_64-darwin12.0`)
Ruby: 1.9.3-p551, 2.1.5, 2.1.6

This behaviour is new to 3.1.0 and was not present in 3.0.9.

The root cause for all of these failures appears to be `Rufus::Scheduler::ZoTime::is_timezone?` returning `true` for inputs like `"*"` or `"1,2,3,4,5"`, which are valid parts of a cronline and do not represent a timezone, which then causes the cronline to get [mangled][].

By adding an explicit require statement, we can ensure that `TZInfo` is used if available, which fixes my local problems, but it's unclear to me whether [the rest][is-timezone-after-tzinfo] of `is_timezone?` is working correctly if it lets strings like `"*"` get detected as timezones.

[failures]: https://gist.github.com/yaauie/4da7b154a4af1d8c2eaf
[CI build]: https://travis-ci.org/jmettraux/rufus-scheduler/builds/58974999
[mangled]: https://github.com/jmettraux/rufus-scheduler/blob/v3.1.0/lib/rufus/scheduler/cronline.rb#L59
[is-timezone-after-tzinfo]: https://github.com/jmettraux/rufus-scheduler/blob/v3.1.0/lib/rufus/scheduler/zotime.rb#L130-L138