### PR TITLE
Fix Scheduler#timeline method stuck in infinite loop with a cron job using a 'first_in:' parameter

### DIFF
--- a/lib/rufus/scheduler/jobs.rb
+++ b/lib/rufus/scheduler/jobs.rb
@@ -621,7 +621,7 @@ module Rufus
 
       def next_time_from(time)
 
-        if @first_at == nil || @first_at < time
+        if @first_at == nil || @first_at <= time
           @cron_line.next_time(time)
         else
           @first_at

--- a/spec/schedule_cron_spec.rb
+++ b/spec/schedule_cron_spec.rb
@@ -62,5 +62,20 @@ describe Rufus::Scheduler do
       expect(job.job_id).to match(/^cron_/)
     end
   end
+
+  describe '#timeline' do
+    it 'should not lock when running timeline with a time_at specified' do
+      now = Time.now
+
+      # Scheduling a cron job with a first_at and running #timeline use
+      # to result in an infinite loop.
+      @scheduler.cron('* * * * * *', first_at: now + 3) {}
+
+      jobs = @scheduler.timeline(now, now + 4)
+      expect(jobs.size).to be 2
+      expect(jobs[0][0]).to be_within_1s_of now + 3
+      expect(jobs[1][0]).to be_within_1s_of now + 4
+    end
+  end
 end
 


### PR DESCRIPTION
Fix for Issue #151. I am not sure if this is the right solution as if the job is created with a `first_at == Time.now`, the first_at would be ignored.