### PR TITLE
Job id uniqueness

### DIFF
--- a/lib/rufus/scheduler/jobs.rb
+++ b/lib/rufus/scheduler/jobs.rb
@@ -351,7 +351,8 @@ module Rufus
           self.class.name.split(':').last.downcase[0..-4],
           @scheduled_at.to_f,
           @next_time.to_f,
-          opts.hash.abs
+          opts.hash.abs,
+          SecureRandom.random_number(1000)
         ].map(&:to_s).join('_')
       end
 
@@ -473,7 +474,8 @@ module Rufus
         [
           self.class.name.split(':').last.downcase[0..-4],
           @scheduled_at.to_f,
-          opts.hash.abs
+          opts.hash.abs,
+          SecureRandom.random_number(1000)
         ].map(&:to_s).join('_')
       end
 


### PR DESCRIPTION
When I make several jobs in a millisecond(same option), job ids are identical.. Later I couldn't retrieve one of the job instance by job method. 
I'm not sure, adding random number is a good solution.. But need to do something on this issue