### PR TITLE
removed male-gendered language

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ There is no EventMachine-based scheduler anymore.
 
 ## I don't know what this Ruby thing is, where are my Rails?
 
-Sir, I'll drive you right to the [tracks](#so-rails).
+I'll drive you right to the [tracks](#so-rails).
 
 
 ## Notable changes:


### PR DESCRIPTION
hi, i'm a nonbinary engineer, and having gendered language at all, *especially* "Sir," in a readme like this is incredibly off-putting and reinforces the idea that most programmers are men. gendered language isn't necessary, even if you're just trying to be playful to the reader. this is just a suggestion. thank you!