### PR TITLE
Acknowledge unscheduled_at in scheduled? method

### DIFF
--- a/lib/rufus/scheduler.rb
+++ b/lib/rufus/scheduler.rb
@@ -387,7 +387,7 @@ module Rufus
 
       job, job_id = fetch(job_or_job_id)
 
-      !! (job && job.next_time != nil)
+      !! (job && job.unscheduled_at.nil? && job.next_time != nil)
     end
 
     # Lists all the threads associated with this scheduler.

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -176,6 +176,16 @@ describe Rufus::Scheduler::Job do
       expect(job.running?).to eq(true)
       expect(job.scheduled?).to eq(true)
     end
+
+    it 'returns false if job is unscheduled' do
+      job = @scheduler.schedule_interval('0.1s') { sleep 0.1 }
+      job.unschedule
+
+      sleep 0.3
+
+      expect(job.running?).to eq(false)
+      expect(job.scheduled?).to eq(false)
+    end
   end
 
   describe '#call' do


### PR DESCRIPTION
While writing some tests for our internal scheduler based on rufus, I realized that `job.unscheduled_at` is not acknowledged in the `scheduled?` method. 
This pull request adds an additional check to the `scheduler.scheduled?` method to ensure the job is still scheduled when returning `true`.