### PR TITLE
Add specs for DST transitions in the Fall

### DIFF
--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -911,5 +911,72 @@ describe Rufus::Scheduler::CronLine do
       end
     end
   end
+
+
+  context 'fall time' do
+    it 'correctly increments through a DST transition' do
+
+      expect(
+        nt('* * * * * America/Los_Angeles', Time.utc(2015, 11, 1, 9, 59))
+      ).to eq(Time.utc(2015, 11, 1, 10, 00))
+    end
+
+    it 'correctly increments every minute through a DST transition' do
+
+      in_zone 'America/Los_Angeles' do
+
+        line = cl('* * * * * America/Los_Angeles')
+
+        t = Time.local(2015, 11, 1, 1, 57)
+
+        points =
+          [ 0, 1, 2, 3 ].collect do
+            t = line.next_time(t)
+            t.strftime('%H:%M:%Sl') + ' ' + t.dup.utc.strftime('%H:%M:%Su')
+          end
+
+        expect(points).to eq(
+          [
+            '01:58:00l 08:58:00u',
+            '01:59:00l 08:59:00u',
+            '01:00:00l 09:00:00u',
+            '01:01:00l 09:01:00u'
+          ]
+        )
+      end
+    end
+
+    it 'correctly decrements through a DST transition' do
+
+      expect(
+        pt('* * * * * America/Los_Angeles', Time.utc(2015, 11, 1, 10, 00))
+      ).to eq(Time.utc(2015, 11, 1, 9, 59))
+    end
+
+    it 'correctly decrements every minute through a DST transition' do
+
+      in_zone 'America/Los_Angeles' do
+
+        line = cl('* * * * * America/Los_Angeles')
+
+        t = Time.local(2015, 11, 1, 1, 2)
+
+        points =
+          [ 0, 1, 2, 3 ].collect do
+            t = line.previous_time(t)
+            t.strftime('%H:%M:%Sl') + ' ' + t.dup.utc.strftime('%H:%M:%Su')
+          end
+
+        expect(points).to eq(
+          [
+            '01:01:00l 09:01:00u',
+            '01:00:00l 09:00:00u',
+            '01:59:00l 08:59:00u',
+            '01:58:00l 08:58:00u'
+          ]
+        )
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
https://github.com/jmettraux/rufus-scheduler/pull/140 added failing dst specs for summer time. We ran into this issue again this past weekend. I added failing specs for fall time.

Output of the failing tests:

```
Failures:

  1) Rufus::Scheduler::CronLine fall time correctly increments through a DST transition
     Failure/Error: expect(
       
       expected: 2015-11-01 09:00:00.000000000 +0000
            got: 2015-11-01 02:00:00.000000000 -0800
       
       (compared using ==)
       
       Diff:
       @@ -1,2 +1,2 @@
       -2015-11-01 09:00:00 UTC
       +2015-11-01 02:00:00 -0800
     # ./spec/cronline_spec.rb:919:in `block (3 levels) in <top (required)>'

  2) Rufus::Scheduler::CronLine fall time correctly increments every minute through a DST transition
     Failure/Error: expect(points).to eq(
       
       expected: ["01:58:00l 08:58:00u", "01:59:00l 08:59:00u", "01:00:00l 09:00:00u", "01:01:00l 09:01:00u"]
            got: ["01:58:00l 09:58:00u", "01:59:00l 09:59:00u", "02:00:00l 10:00:00u", "02:01:00l 10:01:00u"]
       
       (compared using ==)
     # ./spec/cronline_spec.rb:938:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:67:in `call'
     # ./spec/spec_helper.rb:67:in `in_zone'
     # ./spec/cronline_spec.rb:926:in `block (3 levels) in <top (required)>'

  3) Rufus::Scheduler::CronLine fall time correctly decrements every minute through a DST transition
     Failure/Error: expect(points).to eq(
       
       expected: ["01:01:00l 09:01:00u", "01:00:00l 09:00:00u", "01:59:00l 08:59:00u", "01:58:00l 08:58:00u"]
            got: ["01:01:00l 09:01:00u", "01:00:00l 09:00:00u", "01:59:00l 09:59:00u", "01:58:00l 09:58:00u"]
       
       (compared using ==)
     # ./spec/cronline_spec.rb:970:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:67:in `call'
     # ./spec/spec_helper.rb:67:in `in_zone'
     # ./spec/cronline_spec.rb:958:in `block (3 levels) in <top (required)>'
````