### PR TITLE
fixes comparison of Fixnum with nil error

### DIFF
--- a/lib/rufus/scheduler/cronline.rb
+++ b/lib/rufus/scheduler/cronline.rb
@@ -284,7 +284,7 @@ class Rufus::Scheduler
 
     def prev_second(time)
 
-      secs = toa(@seconds)
+      secs = [time.sec] + toa(@seconds)
 
       secs.pop while time.sec < secs.last
 

--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -46,6 +46,9 @@ describe Rufus::Scheduler::CronLine do
   def ns(cronline, now)
     Rufus::Scheduler::CronLine.new(cronline).next_second(now)
   end
+  def ps(cronline, now)
+    Rufus::Scheduler::CronLine.new(cronline).prev_second(now)
+  end
 
   def match(line, time)
     expect(cl(line).matches?(time)).to eq(true)
@@ -469,6 +472,16 @@ describe Rufus::Scheduler::CronLine do
       it "ensures that next_second('#{cronline}', #{now}) is #{sec}" do
         expect(ns(cronline,now)).to eq(sec)
       end
+    end
+  end
+
+  describe '#prev_second' do
+    subject { ps('43,44 * * * * *', time) }
+
+    context 'when time sec is lower then all cron time' do
+      let(:time) { local(1970,1,1,1,1,42) }
+
+      it { is_expected.to eq 0 }
     end
   end
 


### PR DESCRIPTION
Added a spec to show case the issue, not sure if this is the best fix for it.

In some cases the current time sec was lower than all values in the secs array, this was causing pop to empty the array and eventually throw a nil comparison error.