### PR TITLE
Account for using {first: 0} for immediate execution of RepeatJobs

### DIFF
--- a/lib/rufus/scheduler/jobs.rb
+++ b/lib/rufus/scheduler/jobs.rb
@@ -419,14 +419,14 @@ module Rufus
         return @first_at = nil if first == nil
 
         n = Time.now
-        first = n + 0.003 if first == :now || first == :immediately
+        first = n + 0.003 if first == :now || first == :immediately || first == 0
 
         @first_at = Rufus::Scheduler.parse_to_time(first)
 
         raise ArgumentError.new(
           "cannot set first[_at|_in] in the past: " +
           "#{first.inspect} -> #{@first_at.inspect}"
-        ) if first != 0 && @first_at < n
+        ) if @first_at < n
       end
 
       def last_at=(last)


### PR DESCRIPTION
Prior to v3, you could specify the option {first_in: 0} to have the scheduler fire the job immediately. This does not work anymore since only the symbols :now or :immediately are accounted for when setting @first_at to be slightly after Time.now (Time.now + 0.003).
Currently, @first_at will be set to Time.now if the options specify 0 and the scheduler won't fire the job until Time.now + frequency.

The [Dashing dashboard framework](http://shopify.github.io/dashing/) is forced to stay on v2.0.24 due to a large amount of [3rd party widgets](https://github.com/Shopify/dashing/wiki/Additional-Widgets) using {first_in: 0} to specify immediate execution of the scheduled job