### PR TITLE
fix potential time shift in EveryJob

### DIFF
--- a/lib/rufus/scheduler/jobs.rb
+++ b/lib/rufus/scheduler/jobs.rb
@@ -545,7 +545,7 @@ module Rufus
 
         @next_time =
           if @first_at == nil || @first_at < Time.now
-            (trigger_time || Time.now) + @frequency
+            (@next_time || trigger_time || Time.now) + @frequency
           else
             @first_at
           end
@@ -637,4 +637,3 @@ module Rufus
     end
   end
 end
-


### PR DESCRIPTION
Hi,

First I'd like to thank you for this awesome work on rufus-scheduler :)

I use rufus-scheduler (with resque-scheduler) in production to run jobs every 60s and I noticed that the schedule time shifted by ~1s every 15 minutes.

This was problematic to me because I rely heavily on time to do my computations, so I read the code and found the set_next_time method of Rufus::Scheduler::EveryJob was relying on the trigger time to define the next run of the job. I implemented a change to rely on the old @next_time value if it is defined to avoid time shift due to compute time or tick interval, it seems more logical and actually works perfectly for me.

What do you think ?

Please let me know if anything is unclear

Best regards,