### PR TITLE
Use .nil? instead of == nil

### DIFF
--- a/lib/rufus/scheduler.rb
+++ b/lib/rufus/scheduler.rb
@@ -609,7 +609,7 @@ module Rufus
 
       fail NotRunningError.new(
         'cannot schedule, scheduler is down or shutting down'
-      ) if @started_at == nil
+      ) if @started_at.nil?
 
       callable, opts = nil, callable if callable.is_a?(Hash)
       return_job_instance ||= opts[:job]


### PR DESCRIPTION
I was having issues with rufus + ActiveSupport(3.2.22) 

When checking for  @started_at == nil my system tried to use ActiveSupport's "compare_with_coercion" which ended up failing trying to run .to_datetime on null.

Not sure if I'm fixing this in the right place but I thought I'd give it a try.
