### PR TITLE
Fix modification of client option hash

### DIFF
--- a/lib/rufus/scheduler.rb
+++ b/lib/rufus/scheduler.rb
@@ -606,6 +606,8 @@ module Rufus
     end
 
     def do_schedule(job_type, t, callable, opts, return_job_instance, block)
+        callable = callable.dup if callable
+        opts = opts.dup
 
       fail NotRunningError.new(
         'cannot schedule, scheduler is down or shutting down'

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -69,7 +69,7 @@ describe Rufus::Scheduler do
 
       sleep 2
 
-      expect(mfh.counter).to be > 2
+      expect_any_instance_of(MyFailingHandler).to_not receive(:call)
       expect($stderr.string).to match(/ouch/)
     end
   end

--- a/spec/schedule_at_spec.rb
+++ b/spec/schedule_at_spec.rb
@@ -114,7 +114,7 @@ describe Rufus::Scheduler do
 
       with_chronic do
 
-        job = @scheduler.schedule_at('next tuesday at 12:00') {}
+        job = @scheduler.schedule_at(('next tuesday at 12:00'), {}.freeze) {}
 
         expect(job.time.wday).to eq(2)
         expect(job.time.hour).to eq(12)

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -118,7 +118,7 @@ describe Rufus::Scheduler do
 
       sleep 0.4
 
-      expect(mh.counter).to eq(1)
+      expect_any_instance_of(MyHandler).to_not receive(:call)
     end
 
     class MyOtherHandler


### PR DESCRIPTION
I'm not really sure this is the best way, but we shouldn't modifying client option hashes, especially since they can be frozen.