### PR TITLE
Speedup brute frequency

### DIFF
--- a/lib/rufus/scheduler/cronline.rb
+++ b/lib/rufus/scheduler/cronline.rb
@@ -279,8 +279,10 @@ class Rufus::Scheduler
 #p Time.now - st
         d = t1 - t0
         delta = d if d < delta
-
-        break if @months == nil && t1.month == 2
+        break if @months.nil? && t1.month == 2
+        break if @months.nil? && @days.nil? && t1.day == 2
+        break if @months.nil? && @days.nil? && @hours.nil? && t1.hour == 1
+        break if @months.nil? && @days.nil? && @hours.nil? && @minutes.nil? && t1.min == 1
         break if t1.year >= 2001
 
         t0 = t1

--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -829,6 +829,14 @@ describe Rufus::Scheduler::CronLine do
         '5 * * * *').brute_frequency).to eq(3600)
       expect(Rufus::Scheduler::CronLine.new(
         '10,20,30 * * * *').brute_frequency).to eq(600)
+      expect(Rufus::Scheduler::CronLine.new(
+        '* 1 * * sun#2,sun#3').brute_frequency).to eq(60)
+      expect(Rufus::Scheduler::CronLine.new(
+        '0 0,12 1 */2 *').brute_frequency).to eq(43200)
+      expect(Rufus::Scheduler::CronLine.new(
+        '0 4 15-21 * *').brute_frequency).to eq(86400)
+      expect(Rufus::Scheduler::CronLine.new(
+        '1,2 * * * * 1-5').brute_frequency).to eq(1)
     end
 
     it 'returns the shortest delta between two occurrences (6 fields)' do
@@ -836,10 +844,8 @@ describe Rufus::Scheduler::CronLine do
       expect(Rufus::Scheduler::CronLine.new(
         '* * * * * *').brute_frequency).to eq(1)
 
-      #Rufus::Scheduler::CronLine.new(
-      #    '10,20,30 * * * * *').brute_frequency.should == 10
-        #
-        # takes > 20s ...
+      expect(Rufus::Scheduler::CronLine.new(
+        '10,20,30 * * * * *').brute_frequency).to eq(10)
     end
 
     # some combos only appear every other year...


### PR DESCRIPTION
By breaking out of the loop as early as possible `brute_frequency` has to do less iterations, which significantly speeds up cronlines with second or minute intervals.

The cronline_spec now runs about 35 times faster.