### PR TITLE
Support combination of weekdays and monthdays in cronline

### DIFF
--- a/lib/rufus/scheduler/cronline.rb
+++ b/lib/rufus/scheduler/cronline.rb
@@ -32,6 +32,7 @@ class Rufus::Scheduler
   # (man 5 crontab) file line.
   #
   class CronLine
+    NEXT_TIME_YEAR_LIMIT = Date.today.year + 10
 
     # The string used for creating this cronline instance.
     #
@@ -142,6 +143,10 @@ class Rufus::Scheduler
 
         nt = zt.dup
 
+        fail ArgumentError.new(
+          "failed to calculate next time for '#{original}'"
+        ) if nt.year > NEXT_TIME_YEAR_LIMIT
+
         unless date_match?(nt)
           zt.add((24 - nt.hour) * 3600 - nt.min * 60 - nt.sec)
           next
@@ -176,6 +181,10 @@ class Rufus::Scheduler
       loop do
 
         pt = zt.dup
+
+        fail ArgumentError.new(
+          "failed to calculate previous time for '#{original}'"
+        ) if pt.year < 1965
 
         unless date_match?(pt)
           zt.substract(pt.hour * 3600 + pt.min * 60 + pt.sec + 1)

--- a/lib/rufus/scheduler/cronline.rb
+++ b/lib/rufus/scheduler/cronline.rb
@@ -499,8 +499,10 @@ class Rufus::Scheduler
 
       return false unless sub_match?(zt, :day, @days)
       return false unless sub_match?(zt, :month, @months)
+      if @weekdays && @monthdays
+        return true if sub_match?(zt, :wday, @weekdays) || sub_match?(zt, :monthdays, @monthdays)
+      end
       return false unless sub_match?(zt, :wday, @weekdays)
-      #return false unless monthday_match?(zt, @monthdays)
       return false unless sub_match?(zt, :monthdays, @monthdays)
       true
     end

--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -509,6 +509,12 @@ describe Rufus::Scheduler::CronLine do
         eq(zlocal(1970, 1, 1, 1, 2, 00))
       )
     end
+
+    it 'is not stuck in an infite loop when the calculation fails' do
+      cronline = cl('0 0 * * mon#2,tue')
+      allow(cronline).to receive(:date_match?).and_return(false)
+      expect { cronline.next_time }.to raise_error(ArgumentError)
+    end
   end
 
   describe '#next_second' do
@@ -641,6 +647,12 @@ describe Rufus::Scheduler::CronLine do
       expect(
         pt('* */10 * * *', lo(2000, 1, 1))).to eq(
           zlo(1999, 12, 31, 20, 59, 00))
+    end
+
+    it 'is not stuck in an infite loop when the calculation fails' do
+      cronline = cl('0 0 * * mon#2,tue')
+      allow(cronline).to receive(:date_match?).and_return(false)
+      expect { cronline.previous_time }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/cronline_spec.rb
+++ b/spec/cronline_spec.rb
@@ -73,6 +73,7 @@ describe Rufus::Scheduler::CronLine do
       a_eq '* * * * sun,2-4', [ [0], nil, nil, nil, nil, [0, 2, 3, 4], nil ]
 
       a_eq '* * * * sun,mon-tue', [ [0], nil, nil, nil, nil, [0, 1, 2], nil ]
+      a_eq '0 0 * * mon#1,tue', [[0], [0], [0], nil, nil, [2], ["1#1"]]
 
       a_eq '* * * * * *', [ nil, nil, nil, nil, nil, nil, nil ]
       a_eq '1 * * * * *', [ [1], nil, nil, nil, nil, nil, nil ]
@@ -406,6 +407,13 @@ describe Rufus::Scheduler::CronLine do
         nt('* * * * sun#2,sun#3', zlo(1970, 1, 1))).to eq(zlo(1970, 1, 11))
       expect(
         nt('* * * * sun#2,sun#3', zlo(1970, 1, 12))).to eq(zlo(1970, 1, 18))
+    end
+
+    it 'computs next time correctly when weekdays is combined with monthdays' do
+      expect(
+        nt('* * * * mon#2,tue', zlo(2016, 12, 1))).to eq(zlo(2016, 12, 6))
+      expect(
+        nt('* * * * mon#2,tue', zlo(2016, 12, 7))).to eq(zlo(2016, 12, 12))
     end
 
     it 'understands sun#L and co' do
@@ -845,6 +853,8 @@ describe Rufus::Scheduler::CronLine do
         '* 1 * * sun#2,sun#3').brute_frequency).to eq(60)
       expect(Rufus::Scheduler::CronLine.new(
         '0 0,12 1 */2 *').brute_frequency).to eq(43200)
+      expect(Rufus::Scheduler::CronLine.new(
+        '* * * * mon#2,tue').brute_frequency).to eq(60)
       expect(Rufus::Scheduler::CronLine.new(
         '0 4 15-21 * *').brute_frequency).to eq(86400)
       expect(Rufus::Scheduler::CronLine.new(


### PR DESCRIPTION
The first commit ensures `previous_time` and `next_time` are not stuck in an infinite loop, which happened before when combining weekdays and monthdays in a cronline.
The second commit fixes that use case by modifying `date_match?` to only require one of the expressions to match if both are provided.