### PR TITLE
Fixnum is deprecated in ruby 2.4

### DIFF
--- a/lib/rufus/scheduler/cronline.rb
+++ b/lib/rufus/scheduler/cronline.rb
@@ -86,7 +86,7 @@ class Rufus::Scheduler
 
         fail ArgumentError.new(
           "invalid cronline: '#{line}'"
-        ) if es && es.find { |e| ! e.is_a?(Fixnum) }
+        ) if es && es.find { |e| ! e.is_a?(Integer) }
       end
 
       if @days && @days.include?(0) # gh-221

--- a/lib/rufus/scheduler/jobs.rb
+++ b/lib/rufus/scheduler/jobs.rb
@@ -426,7 +426,7 @@ module Rufus
 
         fail ArgumentError.new(
           "cannot accept :times => #{@times.inspect}, not nil or an int"
-        ) unless @times == nil || @times.is_a?(Fixnum)
+        ) unless @times == nil || @times.is_a?(Integer)
 
         self.first_at =
           opts[:first] || opts[:first_time] ||


### PR DESCRIPTION
in pre-2.4, Fixnum inherits from Integer; in 2.4+
it IS Integer. so it's safe to change these is_a? calls to
just check Integer