### PR TITLE
Fix advanced locking interface

### DIFF
--- a/lib/rufus/scheduler.rb
+++ b/lib/rufus/scheduler.rb
@@ -104,7 +104,7 @@ module Rufus
       @trigger_lock = opts[:trigger_lock] || Rufus::Scheduler::NullLock.new
 
       # If we can't grab the @scheduler_lock, don't run.
-      @scheduler_lock.lock || return
+      lock || return
 
       start
     end


### PR DESCRIPTION
By using the `Scheduler` `lock` function instead of calling `@scheduler_lock.lock` directly. This means that overriding the lock function (as in the Zookeeper example in the docs) will actually do something.