### PR TITLE
Allow a CronLine object as parameter to schedule

### DIFF
--- a/lib/rufus/scheduler/jobs.rb
+++ b/lib/rufus/scheduler/jobs.rb
@@ -610,7 +610,7 @@ module Rufus
 
         super(scheduler, cronline, opts, block)
 
-        @cron_line = opts[:_t] || CronLine.new(cronline)
+        @cron_line = cronline.is_a?(CronLine) ? cronline : opts[:_t] || CronLine.new(cronline)
         set_next_time(nil)
       end
 

--- a/spec/job_cron_spec.rb
+++ b/spec/job_cron_spec.rb
@@ -27,6 +27,17 @@ describe Rufus::Scheduler::CronJob do
 
       expect(job.last_time.to_i % 10).to eq(0)
     end
+
+    context 'when passed a cronline object' do
+      it 'triggers near the zero second' do
+        cl = Rufus::Scheduler::CronLine.new('* * * * *')
+        job = @scheduler.schedule_cron cl do; end
+
+        sleep_until_next_minute
+
+        expect(job.last_time.to_i % 10).to eq(0)
+      end
+    end
   end
 
   #context 'sub-minute' do


### PR DESCRIPTION
Sometimes it's necessary to construct/modify a cronline object dynamically,
and this enables that object to be used as the schedule in addition
to the string parameter syntax.