### PR TITLE
Performance improvements for checking schedule intervals

### DIFF
--- a/lib/rufus/scheduler.rb
+++ b/lib/rufus/scheduler.rb
@@ -616,34 +616,43 @@ module Rufus
 
       job = job_class.new(self, t, opts, block || callable)
 
-      #fail ArgumentError.new(
-      #  "job frequency (#{job.frequency}) is higher than " +
-      #  "scheduler frequency (#{@frequency})"
-      #) if job.respond_to?(:frequency) && job.frequency < @frequency
-        #
-        # This was expensive
+      if job.is_a?(AtJob) || job.is_a?(InJob) || job.is_a?(IntervalJob)
+        # These are all fine
+      elsif job.is_a?(CronJob)
+        # The minimum time delta in a cron job is 1 second, so if our frequency
+        # is less than that we don't need to worry about it.
+        if @frequency >= 1
+          now = EtOrbi.now
 
-      if (
-        ! job.is_a?(Rufus::Scheduler::IntervalJob) &&
-        job.methods.include?(:next_time_from)
-      ) then
+          # NB: For jobs that occur frequently brute_frequency is extremely expensive
+          # and using a loop over next_time_from is extremely expensive for jobs
+          # that occur less often. As a result, this is a basic heuristic to choose
+          # whether we need a more in-depth check.
+          delta = 4.times.inject([ job.send(:next_time_from, now) ]) do |a|
+            a << job.send(:next_time_from, a.last); a
+          end[1..-1].each_cons(2).collect { |a, b| b - a }.min
 
-        nts = (1..365)
-          .inject([ job.send(:next_time_from, EtOrbi.now) ]) { |a, i|
-            a << job.send(:next_time_from, a.last); a }
-        deltas = []; prev = nts.shift
-        while (nt = nts.shift); deltas << (nt - prev).to_f; prev = nt; end
+          # NB: One week is the inflection point.
+          if delta >= 604_800
+            frequency = job.brute_frequency.delta_min
+          else
+            frequency = 365.times.inject([ job.send(:next_time_from, now) ]) do |a|
+              a << job.send(:next_time_from, a.last); a
+            end[1..-1].each_cons(2).collect { |a, b| b - a }.min
+          end
 
-        deltas = deltas[1..-1] \
-          if opts.keys.find { |k| k.to_s.match(/\Afirst/) }
-            #
-            # do not consider the first delta if there is a first, first_at,
-            # or first_in involved
-
+          fail ArgumentError.new(
+           "job frequency (min ~#{frequency}s) is higher than " +
+           "scheduler frequency (#{@frequency}s)"
+          ) if frequency < @frequency
+        end
+      elsif job.is_a?(EveryJob)
         fail ArgumentError.new(
-          "job frequency (~max #{deltas.min}s) is higher than " +
-          "scheduler frequency (#{@frequency})"
-        ) if deltas.min < @frequency * 0.9
+         "job frequency (#{job.frequency}s) is higher than " +
+         "scheduler frequency (#{@frequency}s)"
+        ) if job.frequency < @frequency
+      else
+        fail "Unknown job class of #{job.class}"
       end
 
       @jobs.push(job)
@@ -652,4 +661,3 @@ module Rufus
     end
   end
 end
-

--- a/spec/schedule_cron_spec.rb
+++ b/spec/schedule_cron_spec.rb
@@ -49,7 +49,7 @@ describe Rufus::Scheduler do
         @scheduler.cron '* * * * * *' do; end
       }.to raise_error(
         ArgumentError,
-        'job frequency (~max 1.0s) is higher than scheduler frequency (10)'
+        'job frequency (min ~1.0s) is higher than scheduler frequency (10s)'
       )
     end
 
@@ -60,6 +60,26 @@ describe Rufus::Scheduler do
       job = @scheduler.job(job_id)
 
       expect(job.cron_line.object_id).to eq(cl.object_id)
+    end
+
+    it 'is not slow handling frequent cron durations' do
+      @scheduler.frequency = 10
+
+      s = Time.now
+
+      @scheduler.cron '*/15 * * * * *' do; end
+
+      expect(Time.now - s).to be < 1
+    end
+
+    it 'is not slow handling non-frequent cron durations' do
+      @scheduler.frequency = 10
+
+      s = Time.now
+
+      @scheduler.cron '31 18 18 10 *' do; end
+
+      expect(Time.now - s).to be < 1
     end
   end
 
@@ -83,4 +103,3 @@ describe Rufus::Scheduler do
     end
   end
 end
-


### PR DESCRIPTION
When working with large schedules of jobs (~100) that run infrequently (weekly or less) our Sidekiq server can take 8 to 10 minutes to start due to the check to ensure jobs don't run more frequently than the scheduler.

For Cron jobs, Fugit supports up to 1 second cron resolution, the entire check is skipped if the scheduler frequency is below that. Then based on a simple heuristic if the minimum delta between the 2nd, 3rd, and 4th runtimes is greater than a week the brute_frequency method is used. Otherwise the old enumeration logic over next_time_from is used.

I added simple specs to ensure adding both frequent and infrequent cron additions take less than a second (on master the infrequent spec takes 12 seconds).

This reduces the schedule parsing time for us to just under 20s.