### PR TITLE
Fix a broken link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Yes, issues can be reported in [rufus-scheduler issues](https://github.com/jmett
 ### faq
 
 * [It doesn't work...](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
-* [I want a refund](http://blog.nodejitsu.com/getting-refunds-on-open-source-projects)
+* [I want a refund](https://blog.nodejitsu.com/getting-refunds-on-open-source-projects)
 * [Passenger and rufus-scheduler](http://stackoverflow.com/questions/18108719/debugging-rufus-scheduler/18156180#18156180)
 * [Passenger and rufus-scheduler (2)](http://stackoverflow.com/questions/21861387/rufus-cron-job-not-working-in-apache-passenger#answer-21868555)
 * [Passenger in-depth spawn methods](https://www.phusionpassenger.com/library/indepth/ruby/spawn_methods/)


### PR DESCRIPTION
The link to the *Getting refunds on open-source projects* post kept timing out for me. Changing it to https (a good idea regardless 🙂 ) fixed it.