### PR TITLE
Update README for test env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,17 +1573,14 @@ require 'rufus-scheduler'
 
 s = Rufus::Scheduler.singleton
 
+return if defined?(Rails::Console) || Rails.env.test? || File.split($0).last == 'rake'
 
-unless defined?(Rails::Console) || File.split($0).last == 'rake'
+# only schedule when not running from the Ruby on Rails console, test env,
+# or from a rake task
 
-  # only schedule when not running from the Ruby on Rails console
-  # or from a rake task
-
-  s.every '1m' do
-
-    Rails.logger.info "hello, it's #{Time.now}"
-    Rails.logger.flush
-  end
+s.every '1m' do
+  Rails.logger.info "hello, it's #{Time.now}"
+  Rails.logger.flush
 end
 ```
 


### PR DESCRIPTION
Also use the ruby feature allowing you to skip the rest of a module with an early top level return (https://bugs.ruby-lang.org/issues/4840).