### PR TITLE
make us of opts in parse_cron and raise error

### DIFF
--- a/lib/rufus/scheduler/util.rb
+++ b/lib/rufus/scheduler/util.rb
@@ -19,9 +19,11 @@ module Rufus
         fail(ArgumentError.new("couldn't parse #{o.inspect} (#{o.class})"))
       end
 
-      def parse_cron(o, opts)
+      def parse_cron(o, opts ={})
 
-        Fugit.parse_cron(o)
+        opts[:no_error] ? 
+          Fugit.parse_cron(o) :
+          Fugit.do_parse_cron(o)
       end
 
       def parse_in(o, opts={})


### PR DESCRIPTION
`parse_cron` method was expecting an "required" option hash as parameter but it was not used at all. This commit changes the parameter to an "optional" one and actually uses it to determine if the method should return nil or raise an error.(as other parse methods). `Fugit.do_parse_cron` is just like `parse_cron` but it raises an "ArgumentError" if the string cannot be parsed.