### PR TITLE
Remove rubyforge_project from specification

### DIFF
--- a/rufus-scheduler.gemspec
+++ b/rufus-scheduler.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.authors = [ 'John Mettraux' ]
   s.email = [ 'jmettraux@gmail.com' ]
   s.homepage = 'http://github.com/jmettraux/rufus-scheduler'
-  s.rubyforge_project = 'rufus'
   s.license = 'MIT'
   s.summary = 'job scheduler for Ruby (at, cron, in and every jobs)'
 


### PR DESCRIPTION
Rubyforge is long gone. As of rubygems 3.1, having this in the spec will cause a warning.