### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/rufus-scheduler.gemspec
+++ b/rufus-scheduler.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.authors = [ 'John Mettraux' ]
   s.email = [ 'jmettraux@gmail.com' ]
-  s.homepage = 'http://github.com/jmettraux/rufus-scheduler'
+  s.homepage = 'https://github.com/jmettraux/rufus-scheduler'
   s.license = 'MIT'
   s.summary = 'job scheduler for Ruby (at, cron, in and every jobs)'
 


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/rufus-scheduler or some tools or APIs that use the gem's metadata.