### PR TITLE
Fix warning: assigned but unused variable - e

### DIFF
--- a/lib/rufus/scheduler.rb
+++ b/lib/rufus/scheduler.rb
@@ -583,7 +583,7 @@ class Rufus::Scheduler
       r =
         begin
           @join_queue.pop(true)
-        rescue ThreadError => e
+        rescue ThreadError => _
           # #<ThreadError: queue empty>
           false
         end


### PR DESCRIPTION
## Problem
When using the rufus scheduler in a project with sorbet type checking, we get the following warning:
```bash
~/.gem/ruby/3.0.3/gems/rufus-scheduler-3.8.0/lib/rufus/scheduler.rb:587: warning: assigned but unused variable - e
```

## Solution
use `_` instead of `e` to make it clear that it's an unused variable.