### PR TITLE
CI: Avoid extra "bundle install"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,10 +25,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
-          bundler-cache: true
+          bundler-cache: true # 'bundle install' and cache
       - run: ruby --version
       - run: gem --version
       - run: bundle --version
-      - run: bundle install
       - run: bundle exec rspec --force-color --format documentation
 


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.