### PR TITLE
Optionally allow first_at to be set in the past

### DIFF
--- a/lib/rufus/scheduler/jobs_repeat.rb
+++ b/lib/rufus/scheduler/jobs_repeat.rb
@@ -15,6 +15,8 @@ class Rufus::Scheduler::RepeatJob < Rufus::Scheduler::Job
 
     @times = opts[:times]
 
+    @first_at_no_error = opts[:first_at_no_error] || false
+
     fail ArgumentError.new(
       "cannot accept :times => #{@times.inspect}, not nil or an int"
     ) unless @times == nil || @times.is_a?(Integer)
@@ -43,6 +45,7 @@ class Rufus::Scheduler::RepeatJob < Rufus::Scheduler::Job
 
     @first_at = (fdur && (EoTime.now + fdur)) || EoTime.make(first)
     @first_at = n1 if @first_at >= n0 && @first_at < n1
+    @first_at = n0 if @first_at < n0 && @first_at_no_error
 
     fail ArgumentError.new(
       "cannot set first[_at|_in] in the past: " +
@@ -319,4 +322,3 @@ class Rufus::Scheduler::CronJob < Rufus::Scheduler::RepeatJob
       end
   end
 end
-

--- a/spec/job_repeat_spec.rb
+++ b/spec/job_repeat_spec.rb
@@ -191,6 +191,15 @@ describe Rufus::Scheduler::RepeatJob do
       }.to raise_error(ArgumentError)
     end
 
+    it 'does not raise on points in the past when first_at_no_error is set' do
+      n = Time.now
+      job =
+          @scheduler.schedule_every '7s',
+                                    { :first => Time.now - 60, :first_at_no_error => true } do; end
+
+      expect(job.first_at).to be < n + 0.7
+    end
+
     context ':first_time => :now/:immediately/0' do
 
       it 'schedules the first execution immediately (:first => :now)' do
@@ -439,4 +448,3 @@ describe Rufus::Scheduler::RepeatJob do
     end
   end
 end
-


### PR DESCRIPTION
First off - thanks for creating and maintaining this great library, my team has been using it for many years. However, one thing that has consistently plagued us throughout the years is the `ArgumentError` thrown if `first_at` is in the past. We use `rufus-scheduler` via `resque-scheduler`, and unfortunately we have seen wildly inconsistent performance when saving new schedules (sometimes up to 2 minutes between when we save and when rufus processes the schedule). Because of this, even if we pass in a `first_at` in the future, when rufus processes the job it is no longer in the future and throws an error and crashes the scheduler. As a workaround, we have had to add in an an artificial buffer that if our desired `first_at` is less than 2 minutes from now, set it to nil instead so rufus does not throw an error.  

However, this behavior isn't entirely desirable since it can skew the execution time of our schedules.  We'd much prefer to not to have to handle the buffer on our side, and pass in an option which will accept a first_at in the past and set it to `:now` if it is.

Would you be open to allowing this option? This would GREATLY help us. The amount of time we have spent implementing various workarounds is truly inconceivable.

Note: Ruby is not one of my most proficient languages so apologies in advance. Feel free to edit/change as needed.