### PR TITLE
Add Puma plugin

### DIFF
--- a/lib/puma/plugin/rufus_scheduler.rb
+++ b/lib/puma/plugin/rufus_scheduler.rb
@@ -1,0 +1,16 @@
+require "puma/plugin"
+
+Puma::Plugin.create do
+  def start(launcher)
+    in_background do
+      relative_path = ENV["RUFUS_SCHEDULER_PATH"] || "config/scheduler.rb"
+      absolute_path = File.expand_path(relative_path, Dir.pwd)
+
+      if File.exist?(absolute_path)
+        eval(File.read(absolute_path))
+      else
+        launcher.log_writer.error "Rufus Scheduler file not found at #{absolute_path}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR add a first approach to implements a Puma plugin for run Rufus Scheduler in background.

### configure puma

```ruby
# config/puma.rb

plugin :rufus_scheduler
```

### create scheduler config

```ruby
# config/scheduler.rb

scheduler = Rufus::Scheduler.new

scheduler.every "5s" do
  puts "Every 5 seconds #{Time.current}"
end

scheduler.join
```

### run puma

```
$ bin/rails server

=> Booting Puma
=> Rails 7.1.3.2 application starting in development
...

Every 5 seconds 2024-04-17 14:13:11 UTC
Every 5 seconds 2024-04-17 14:13:16 UTC
Every 5 seconds 2024-04-17 14:13:21 UTC
```

### change scheduler path

```
$ RUFUS_SCHEDULER_PATH="config/my_scheduler.rb" bin/rails server
```