### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/rufus-scheduler.gemspec
+++ b/rufus-scheduler.gemspec
@@ -26,6 +26,7 @@ Job scheduler for Ruby (at, cron, in and every jobs). Not a replacement for cron
     #'wiki_uri' => s.homepage + '/flor/wiki',
     #'documentation_uri' => s.homepage + '/tree/master/doc',
     #'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/floraison',
+    'rubygems_mfa_required' => 'true',
   }
 
   #s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
Pupular gems with 180M+ downloads implicitly requires that all privileged operations by any of the owners require OTP.

At the moment of this commit, `rufus-scheduler` has 109M+ downloads, so this commit makes the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Also, by explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and "VERSION PUBLISHED WITH MFA" in the sidebar at https://github.com/jmettraux/rufus-scheduler

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/